### PR TITLE
Add react-leaflet@2 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "leaflet": "^1.0.2",
-    "react-leaflet": "^1.0.1"
+    "react-leaflet": "^1.0.1 || ^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
`react-leaflet-choropleth` works well with `react-leaflet@2`, but `npm i` shows a warning that `react-leaflet@1` is not installed.
This fixes that warning.