### PR TITLE
Update dependencies version of react-leaflet

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "leaflet": "^1.0.2",
-    "react-leaflet": "^1.0.1 || ^2.0.0"
+    "react-leaflet": "^1.0.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
react-leaflet v3 released and this library works with v3.